### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: Continuous Integration
+
+on:
+  push:
+
+  pull_request:
+
+env:
+  PUBLISH_IMAGE: ${{ (github.ref_name == 'main' || github.ref_type == 'tag') && 'TRUE' || 'FALSE'}}
+  IMAGE_TAG: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv
+
+jobs:
+  run-dagger-ci:
+    runs-on: ubuntu-22.04
+    steps:
+
+      - name: grab code
+        uses: actions/checkout@v4
+
+      - name: login to container registry
+        if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.USER_FOR_REGISTRY }}
+          password: ${{ secrets.PAT_FOR_REGISTRY }}
+
+      - name: run ci
+        uses: dagger/dagger-for-github@v5
+        with:
+          version: "latest"
+          verb: call
+          module: continuous-integration
+          args: >-
+            build-image
+            --repo-root-path=.
+            ${{ env.PUBLISH_IMAGE == 'TRUE' && format('--publish-docker-image {0}:{1}', env.IMAGE_NAME, env.IMAGE_TAG)  || ''}}

--- a/continuous-integration/dagger.json
+++ b/continuous-integration/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "continuous-integration",
+  "sdk": "typescript",
+  "source": "dagger",
+  "engineVersion": "v0.11.4"
+}

--- a/continuous-integration/dagger/.gitattributes
+++ b/continuous-integration/dagger/.gitattributes
@@ -1,0 +1,1 @@
+/sdk/** linguist-generated

--- a/continuous-integration/dagger/.gitignore
+++ b/continuous-integration/dagger/.gitignore
@@ -1,0 +1,2 @@
+/sdk
+/node_modules/**

--- a/continuous-integration/dagger/package.json
+++ b/continuous-integration/dagger/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "typescript": "^5.3.2"
+  },
+  "devDependencies": {
+    "@dagger.io/dagger": "./sdk"
+  }
+}

--- a/continuous-integration/dagger/src/index.ts
+++ b/continuous-integration/dagger/src/index.ts
@@ -1,0 +1,83 @@
+/**
+ * A generated module for ContinuousIntegration functions
+ *
+ * This module has been generated via dagger init and serves as a reference to
+ * basic module structure as you get started with Dagger.
+ *
+ * Two functions have been pre-created. You can modify, delete, or add to them,
+ * as needed. They demonstrate usage of arguments and return types using simple
+ * echo and grep commands. The functions can be called from the dagger CLI or
+ * from one of the SDKs.
+ *
+ * The first line in this comment block is a short description line and the
+ * rest is a long description with more detail on the module's purpose or usage,
+ * if appropriate. All modules should have a short description.
+ */
+import { dag, Container, Directory, object, func } from "@dagger.io/dagger"
+
+@object()
+class ContinuousIntegration {
+  /**
+   * Returns a container that echoes whatever string argument is provided
+   */
+  // @func()
+  // containerEcho(stringArg: string): Container {
+  //   return dag.container().from("alpine:latest").withExec(["echo", stringArg])
+  // }
+  //
+  // /**
+  //  * Returns lines that match a pattern in the files of the provided Directory
+  //  */
+  // @func()
+  // async grepDir(directoryArg: Directory, pattern: string): Promise<string> {
+  //   return dag
+  //     .container()
+  //     .from("alpine:latest")
+  //     .withMountedDirectory("/mnt", directoryArg)
+  //     .withWorkdir("/mnt")
+  //     .withExec(["grep", "-R", pattern, "."])
+  //     .stdout()
+  // }
+
+  /**
+   * Build the project's docker image and optionally publish it in a registry.
+   *
+   * @param repoRootPath
+   * @param publishDockerImage
+   */
+  @func()
+  async buildImage(repoRootPath: Directory, publishDockerImage?: string) {
+    // const src = dag.host().directory(repoRootPath)
+    const builtImage = dag
+      .container()
+      .build(
+        repoRootPath,
+        {
+          dockerfile: "Dockerfile"
+        }
+      )
+      .withLabel(
+        "org.opencontainers.image.source",
+        "https://github.com/geobeyond/Arpav-PPCV"
+      )
+
+    if (publishDockerImage) {
+      const sanitizedName = this._sanitizeDockerImageName(publishDockerImage)
+      return await builtImage.publish(sanitizedName)
+    }
+  }
+
+  _sanitizeDockerImageName(dockerImageName: string): string {
+    const host = dockerImageName.substring(0, dockerImageName.indexOf('/'))
+    const path = dockerImageName.substring(dockerImageName.indexOf('/'))
+    let name = path
+    let tag = 'latest'
+    if (path.indexOf(':') > -1) {
+      const tagIndex = path.indexOf(':')
+      name = path.substring(0, tagIndex)
+      tag = path.substring(tagIndex + 1)
+    }
+    return host + name.toLowerCase() + ':' + tag
+  }
+
+}

--- a/continuous-integration/dagger/tsconfig.json
+++ b/continuous-integration/dagger/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "moduleResolution": "Node",
+    "experimentalDecorators": true,
+    "paths": {
+      "@dagger.io/dagger": ["./sdk"],
+      "@dagger.io/dagger/telemetry": ["./sdk/telemetry"]
+    }
+  }
+}


### PR DESCRIPTION
---

# NOTE

Before merging this PR ensure that the following secrets exist on this repo:

- `secrets.USER_FOR_REGISTRY` - the name of the user that is to be used to login to the repo's container registry
- `secrets.PAT_FOR_REGISTRY` - the personal access token that is to be used to login to the repo's container registry

---


This PR adds initial components for enabling a Continuous Integration workflow in the repo which for now consists in:

- a [dagger](https://dagger.io/) typescript module that builds the project's docker image from its related `Dockerfile` and optionally publishes it to the repo's container registry

- a github actions workflow file that specifies that all commits that get merged to `main` shall run the aforementioned dagger script

---

- fixes #6