### PR TITLE
Added github workflow for performing deployment to staging env

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,0 +1,26 @@
+# This workflow runs whenever an already published package gets updated,
+# which would happen after the respective image has been built and
+# pushed to the registry
+
+name: Deployment to staging environment
+
+on:
+
+  registry_package:
+    types:
+      - published
+      - updated
+
+concurrency: staging
+
+jobs:
+  initiate-deployment:
+    runs-on: ubuntu-22.04
+    environment: staging
+    steps:
+      - name: Invoke deployment hook
+        uses: distributhor/workflow-webhook@v3
+        with:
+          webhook_url: ${{ secrets.STAGING_WEBHOOK_URL }}
+          webhook_secret: ${{ secrets.STAGING_WEBHOOK_SECRET }}
+          webhook_type: json


### PR DESCRIPTION
## NOTE

**Before merging this PR** ensure that the following secrets exist in the repo's settings:

- `STAGING_WEBHOOK_URL`
- `STAGING_WEBHOOK_SECRET`

the values for these are similar as the ones from the backend repo

---

This PR adds the `deployment.yaml` github workflow file, which works in the exact same way as the one on the backend repo.

Whenever a new docker image is pushed to the repo's container registry, the workflow will trigger a webhook to the staging environment, which eventually results in the staging env performing a redeployment of the system.

---

- fixes #8