### PR TITLE
fix invalid docker label in built image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 env:
   PUBLISH_IMAGE: ${{ (github.ref_name == 'main' || github.ref_type == 'tag') && 'TRUE' || 'FALSE'}}
   IMAGE_TAG: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
-  IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
 
 jobs:
   run-dagger-ci:

--- a/continuous-integration/dagger/src/index.ts
+++ b/continuous-integration/dagger/src/index.ts
@@ -36,11 +36,12 @@ class ContinuousIntegration {
         }
       )
     if (publishDockerImage) {
-      const sanitizedName = this._sanitizeDockerImageName(publishDockerImage)
+      const [, orgName, repoName] = publishDockerImage.split('/')
       const labeledImage = builtImage.withLabel(
         'org.opencontainers.image.source',
-        publishDockerImage.split(':')[0]
+        `https://github.com/${orgName}/${repoName}`,
       )
+      const sanitizedName = this._sanitizeDockerImageName(publishDockerImage)
       return await labeledImage.publish(sanitizedName)
     } else {
       return 'Done!'


### PR DESCRIPTION
As discussed in #20, this PR modifies the CI code in order to attach a label like `org.opencontainers.image.source=https://github.com/geobeyond/arpav-cline-frontend` to container images built in CI.

---

- fixes #20