### PR TITLE
Scoped gh workflow actions to geobeyond remote

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  PUBLISH_IMAGE: ${{ (github.ref_name == 'main' || github.ref_type == 'tag') && 'TRUE' || 'FALSE'}}
+  PUBLISH_IMAGE: ${{ (github.ref_name == 'main' || github.ref_type == 'tag') && github.repository_owner == 'geobeyond' && 'TRUE' || 'FALSE'}}
   IMAGE_TAG: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
   IMAGE_NAME: ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
 

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -15,6 +15,7 @@ concurrency: staging
 
 jobs:
   initiate-deployment:
+    if: github.repository_owner == 'geobeyond'
     runs-on: ubuntu-22.04
     environment: staging
     steps:


### PR DESCRIPTION
This PR is analogous to geobeyond/arpav-cline-backend#446 - github workflow actions that publish the built docker image and that initiate staging deployments are now only enabled if the current context is the geobeyond repo 